### PR TITLE
Build the migration script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Realm Users Migration Configuration
+# Copy this file to .env and fill in your values
+
+# This is the public key from the API key you generated from Atlas UI or CLI
+USERNAME=your_username
+
+# This is the private key you generated from Atlas UI or CLI
+API_KEY=your_api_key
+
+# This is the project ID you'd like to extract users from
+PROJECT_ID=your_project_id
+
+# This is the app ID you'd like to extract users from
+APP_ID=your_app_id

--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,9 @@ $RECYCLE.BIN/
 
 # Windows shortcuts
 *.lnk
+
+# Environment variables
+.env
+
+# Output directory
+output

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.1",
     "@types/node": "^22.13.14",
+    "@types/yargs": "^17.0.33",
     "@typescript-eslint/eslint-plugin": "^8.28.0",
     "@typescript-eslint/parser": "^8.28.0",
     "eslint": "^9.23.0",
@@ -27,5 +28,11 @@
     "eslint-plugin-prettier": "^5.2.5",
     "prettier": "^3.5.3",
     "typescript": "^5.8.2"
+  },
+  "dependencies": {
+    "axios": "^1.8.4",
+    "chalk": "^5.4.1",
+    "dotenv": "^16.4.7",
+    "yargs": "^17.7.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,19 @@ settings:
 importers:
 
   .:
+    dependencies:
+      axios:
+        specifier: ^1.8.4
+        version: 1.8.4
+      chalk:
+        specifier: ^5.4.1
+        version: 5.4.1
+      dotenv:
+        specifier: ^16.4.7
+        version: 16.4.7
+      yargs:
+        specifier: ^17.7.2
+        version: 17.7.2
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3.3.1
@@ -14,6 +27,9 @@ importers:
       '@types/node':
         specifier: ^22.13.14
         version: 22.13.14
+      '@types/yargs':
+        specifier: ^17.0.33
+        version: 17.0.33
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.28.0
         version: 8.28.0(@typescript-eslint/parser@8.28.0(eslint@9.23.0)(typescript@5.8.2))(eslint@9.23.0)(typescript@5.8.2)
@@ -121,6 +137,12 @@ packages:
   '@types/node@22.13.14':
     resolution: {integrity: sha512-Zs/Ollc1SJ8nKUAgc7ivOEdIBM8JAKgrqqUYi2J997JuKO7/tpQC+WCetQ1sypiKCQWHdvdg9wBNpUPEWZae7w==}
 
+  '@types/yargs-parser@21.0.3':
+    resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
+
+  '@types/yargs@17.0.33':
+    resolution: {integrity: sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==}
+
   '@typescript-eslint/eslint-plugin@8.28.0':
     resolution: {integrity: sha512-lvFK3TCGAHsItNdWZ/1FkvpzCxTHUVuFrdnOGLMa0GGCFIbCgQWVk3CzCGdA7kM3qGVc+dfW9tr0Z/sHnGDFyg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -181,12 +203,22 @@ packages:
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  axios@1.8.4:
+    resolution: {integrity: sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -201,6 +233,10 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
@@ -209,12 +245,24 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
+  chalk@5.4.1:
+    resolution: {integrity: sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -234,6 +282,41 @@ packages:
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
+  dotenv@16.4.7:
+    resolution: {integrity: sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==}
+    engines: {node: '>=12'}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -339,6 +422,34 @@ packages:
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
 
+  follow-redirects@1.15.9:
+    resolution: {integrity: sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
+  form-data@4.0.2:
+    resolution: {integrity: sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==}
+    engines: {node: '>= 6'}
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -351,12 +462,28 @@ packages:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -373,6 +500,10 @@ packages:
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
 
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
@@ -412,6 +543,10 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -419,6 +554,14 @@ packages:
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -474,12 +617,19 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -503,6 +653,14 @@ packages:
 
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
 
   strip-json-comments@3.1.1:
@@ -553,6 +711,22 @@ packages:
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -638,6 +812,12 @@ snapshots:
   '@types/node@22.13.14':
     dependencies:
       undici-types: 6.20.0
+
+  '@types/yargs-parser@21.0.3': {}
+
+  '@types/yargs@17.0.33':
+    dependencies:
+      '@types/yargs-parser': 21.0.3
 
   '@typescript-eslint/eslint-plugin@8.28.0(@typescript-eslint/parser@8.28.0(eslint@9.23.0)(typescript@5.8.2))(eslint@9.23.0)(typescript@5.8.2)':
     dependencies:
@@ -729,11 +909,23 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ansi-regex@5.0.1: {}
+
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
 
   argparse@2.0.1: {}
+
+  asynckit@0.4.0: {}
+
+  axios@1.8.4:
+    dependencies:
+      follow-redirects: 1.15.9
+      form-data: 4.0.2
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
 
   balanced-match@1.0.2: {}
 
@@ -750,6 +942,11 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
   callsites@3.1.0: {}
 
   chalk@4.1.2:
@@ -757,11 +954,23 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  chalk@5.4.1: {}
+
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
 
   concat-map@0.0.1: {}
 
@@ -776,6 +985,35 @@ snapshots:
       ms: 2.1.3
 
   deep-is@0.1.4: {}
+
+  delayed-stream@1.0.0: {}
+
+  dotenv@16.4.7: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  emoji-regex@8.0.0: {}
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
+
+  escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -899,6 +1137,37 @@ snapshots:
 
   flatted@3.3.3: {}
 
+  follow-redirects@1.15.9: {}
+
+  form-data@4.0.2:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      mime-types: 2.1.35
+
+  function-bind@1.1.2: {}
+
+  get-caller-file@2.0.5: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
+
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -909,9 +1178,21 @@ snapshots:
 
   globals@14.0.0: {}
 
+  gopd@1.2.0: {}
+
   graphemer@1.4.0: {}
 
   has-flag@4.0.0: {}
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
 
   ignore@5.3.2: {}
 
@@ -923,6 +1204,8 @@ snapshots:
   imurmurhash@0.1.4: {}
 
   is-extglob@2.1.1: {}
+
+  is-fullwidth-code-point@3.0.0: {}
 
   is-glob@4.0.3:
     dependencies:
@@ -957,12 +1240,20 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
+  math-intrinsics@1.1.0: {}
+
   merge2@1.4.1: {}
 
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.1
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
 
   minimatch@3.1.2:
     dependencies:
@@ -1011,9 +1302,13 @@ snapshots:
 
   prettier@3.5.3: {}
 
+  proxy-from-env@1.1.0: {}
+
   punycode@2.3.1: {}
 
   queue-microtask@1.2.3: {}
+
+  require-directory@2.1.1: {}
 
   resolve-from@4.0.0: {}
 
@@ -1030,6 +1325,16 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
 
   strip-json-comments@3.1.1: {}
 
@@ -1069,5 +1374,25 @@ snapshots:
       isexe: 2.0.0
 
   word-wrap@1.2.5: {}
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  y18n@5.0.8: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}

--- a/src/atlas.ts
+++ b/src/atlas.ts
@@ -1,0 +1,289 @@
+/**
+ * Atlas API functions for the Realm users migration script
+ */
+import axios from 'axios';
+import { log } from './utils';
+
+/**
+ * Get an API token for authentication with MongoDB Atlas API
+ *
+ * @param {string} username - MongoDB Atlas username
+ * @param {string} apiKey - MongoDB Atlas API key
+ * @param {boolean} verbose - Whether to show debug logs
+ * @returns {Promise<string>} - The API token for authentication
+ * @throws {Error} - If authentication fails
+ */
+export const getAPIToken = async (
+  username: string,
+  apiKey: string,
+  verbose: boolean
+): Promise<string> => {
+  try {
+    log.debug(verbose, 'Authenticating with MongoDB Atlas...');
+
+    const response = await axios.post(
+      'https://services.cloud.mongodb.com/api/admin/v3.0/auth/providers/mongodb-cloud/login',
+      {
+        username,
+        apiKey,
+      },
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+      }
+    );
+
+    log.debug(verbose, 'Authentication successful');
+    return response.data.access_token;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      log.error('Authentication failed:', error.response.status, error.response.statusText);
+      log.debug(verbose, 'Error details:', error.response.data);
+    } else {
+      log.error('Error getting API token:', error);
+    }
+    throw error;
+  }
+};
+
+/**
+ * Get users from App Services with optional pagination
+ *
+ * @param {string} accessToken - API token for authentication
+ * @param {string} groupID - MongoDB Atlas Group ID
+ * @param {string} appID - MongoDB Atlas App ID
+ * @param {boolean} verbose - Whether to show debug logs
+ * @param {number} lastId - ID of the last user retrieved for pagination (optional)
+ * @returns {Promise<any[]>} - Array of users from the API
+ * @throws {Error} - If the API call fails
+ */
+export const getUsersFromAppServices = async (
+  accessToken: string,
+  groupID: string,
+  appID: string,
+  verbose: boolean,
+  lastId = 0
+): Promise<any[]> => {
+  try {
+    const userQuery = lastId === 0 ? '' : `?after=${lastId}`;
+    const url = `https://services.cloud.mongodb.com/api/admin/v3.0/groups/${groupID}/apps/${appID}/users${userQuery}`;
+    log.debug(verbose, `Fetching users from: ${url}`);
+
+    const response = await axios.get(url, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        Accept: 'application/json',
+      },
+    });
+
+    log.debug(verbose, `Retrieved ${response.data.length} users`);
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      log.error('Error fetching users:', error.response.status, error.response.statusText);
+      log.debug(verbose, 'Error details:', error.response.data);
+    } else {
+      log.error('Error fetching users:', error);
+    }
+    throw error;
+  }
+};
+
+/**
+ * Get all users with pagination support
+ *
+ * @param {string} accessToken - API token for authentication
+ * @param {string} groupID - MongoDB Atlas Group ID
+ * @param {string} appID - MongoDB Atlas App ID
+ * @param {boolean} verbose - Whether to show debug logs
+ * @returns {Promise<any[]>} - Array of processed user data
+ * @throws {Error} - If the API call fails
+ */
+export const getUsers = async (
+  accessToken: string,
+  groupID: string,
+  appID: string,
+  verbose: boolean
+): Promise<any[]> => {
+  try {
+    log.debug(verbose, 'Getting all users...');
+
+    let users: any[] = [];
+    let returnedUsers = await getUsersFromAppServices(accessToken, groupID, appID, verbose);
+    users = users.concat(returnedUsers);
+
+    while (returnedUsers && returnedUsers.length) {
+      const lastUser = returnedUsers[returnedUsers.length - 1];
+      returnedUsers = await getUsersFromAppServices(
+        accessToken,
+        groupID,
+        appID,
+        verbose,
+        lastUser._id
+      );
+      users = users.concat(returnedUsers);
+    }
+
+    log.debug(verbose, `Total users retrieved: ${users.length}`);
+
+    const userData = users.map((user) => ({
+      id: user._id,
+      email: user.data.email,
+      createdAt: user.creation_date,
+      status: 'active',
+    }));
+
+    return userData;
+  } catch (error) {
+    log.error('Error getting all users:', error);
+    throw error;
+  }
+};
+
+/**
+ * Get pending users from App Services with optional pagination
+ *
+ * @param {string} accessToken - API token for authentication
+ * @param {string} groupID - MongoDB Atlas Group ID
+ * @param {string} appID - MongoDB Atlas App ID
+ * @param {boolean} verbose - Whether to show debug logs
+ * @param {number} lastId - ID of the last pending user retrieved for pagination (optional)
+ * @returns {Promise<any[]>} - Array of pending users from the API
+ * @throws {Error} - If the API call fails
+ */
+export const getPendingUsersFromAppServices = async (
+  accessToken: string,
+  groupID: string,
+  appID: string,
+  verbose: boolean,
+  lastId = 0
+): Promise<any[]> => {
+  try {
+    const userQuery = lastId === 0 ? '' : `?after=${lastId}`;
+    const url = `https://services.cloud.mongodb.com/api/admin/v3.0/groups/${groupID}/apps/${appID}/user_registrations/pending_users${userQuery}`;
+    log.debug(verbose, `Fetching pending users from: ${url}`);
+
+    const response = await axios.get(url, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+
+    log.debug(verbose, `Retrieved ${response.data.length} pending users`);
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      log.error('Error fetching pending users:', error.response.status, error.response.statusText);
+      log.debug(verbose, 'Error details:', error.response.data);
+    } else {
+      log.error('Error fetching pending users:', error);
+    }
+    throw error;
+  }
+};
+
+/**
+ * Get all pending users with pagination support
+ *
+ * @param {string} accessToken - API token for authentication
+ * @param {string} groupID - MongoDB Atlas Group ID
+ * @param {string} appID - MongoDB Atlas App ID
+ * @param {string} pendingUserDate - Date to use for pending users in YYYY-MM-DD format
+ * @param {boolean} verbose - Whether to show debug logs
+ * @returns {Promise<any[]>} - Array of processed pending user data
+ * @throws {Error} - If the API call fails
+ */
+export const getPendingUsers = async (
+  accessToken: string,
+  groupID: string,
+  appID: string,
+  pendingUserDate: string,
+  verbose: boolean
+): Promise<any[]> => {
+  try {
+    log.debug(verbose, 'Getting all pending users...');
+
+    let pendingUsers: any[] = [];
+    let returnedPendingUsers = await getPendingUsersFromAppServices(
+      accessToken,
+      groupID,
+      appID,
+      verbose
+    );
+    pendingUsers = pendingUsers.concat(returnedPendingUsers);
+
+    while (returnedPendingUsers && returnedPendingUsers.length) {
+      log.debug(
+        verbose,
+        `Fetching next batch of pending users after ID: ${returnedPendingUsers[returnedPendingUsers.length - 1]._id}`
+      );
+
+      const lastUser = returnedPendingUsers[returnedPendingUsers.length - 1];
+      returnedPendingUsers = await getPendingUsersFromAppServices(
+        accessToken,
+        groupID,
+        appID,
+        verbose,
+        lastUser._id
+      );
+      pendingUsers = pendingUsers.concat(returnedPendingUsers);
+    }
+
+    log.debug(verbose, `Total pending users retrieved: ${pendingUsers.length}`);
+    log.debug(verbose, `Using ${pendingUserDate} as the creation date for pending users`);
+
+    // Convert the pendingUserDate string to a timestamp
+    const createdAtTimestamp = new Date(pendingUserDate).getTime() / 1000;
+
+    const pendingUserData = pendingUsers.map((user) => ({
+      id: user._id,
+      email: user.login_ids[0].id,
+      status: 'pending',
+      createdAt: createdAtTimestamp,
+    }));
+
+    return pendingUserData;
+  } catch (error) {
+    log.error('Error getting all pending users:', error);
+    throw error;
+  }
+};
+
+/**
+ * List all apps in the project
+ *
+ * @param {string} accessToken - API token for authentication
+ * @param {string} groupID - MongoDB Atlas Group ID
+ * @param {boolean} verbose - Whether to show debug logs
+ * @returns {Promise<any[]>} - Array of apps in the project
+ * @throws {Error} - If the API call fails
+ */
+export const listApps = async (
+  accessToken: string,
+  groupID: string,
+  verbose: boolean
+): Promise<any[]> => {
+  try {
+    const url = `https://services.cloud.mongodb.com/api/admin/v3.0/groups/${groupID}/apps`;
+    log.debug(verbose, `Listing apps from: ${url}`);
+
+    const response = await axios.get(url, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+
+    log.debug(verbose, `Retrieved ${response.data.length} apps`);
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      log.error('Error listing apps:', error.response.status, error.response.statusText);
+      log.debug(verbose, 'Error details:', error.response.data);
+    } else {
+      log.error('Error listing apps:', error);
+    }
+    throw error;
+  }
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,192 @@
 /**
  * Main entry point for the Realm users migration script
  */
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+import dotenv from 'dotenv';
+import { getAPIToken, getUsers, getPendingUsers } from './atlas';
+import { log } from './utils';
+import fs from 'fs/promises';
+import path from 'path';
+
+// Load environment variables from .env file
+dotenv.config();
+
+// Define command line arguments
+const argv = yargs(hideBin(process.argv))
+  .options({
+    dryRun: {
+      type: 'boolean',
+      description: 'Run the script without making any changes',
+      default: false,
+    },
+    verbose: {
+      type: 'boolean',
+      description: 'Enable verbose logging',
+      default: false,
+    },
+    batchSize: {
+      type: 'number',
+      description: 'Number of users to process in each batch',
+      default: 100,
+    },
+    outputFile: {
+      type: 'string',
+      description: 'Path to output file for exported users. Will be saved in output directory',
+    },
+    pendingUserDate: {
+      type: 'string',
+      description: 'Date to use for createdAt field of pending users in YYYY-MM-DD format',
+      default: '2020-12-01',
+    },
+  })
+  .help()
+  .alias('help', 'h')
+  .parseSync();
 
 const main = async (): Promise<void> => {
   try {
-    console.log('Realm users migration script started');
-    // Your migration logic will go here
+    log.info('Realm users migration script started');
+
+    // Get configuration from environment variables
+    const username = process.env.USERNAME;
+    const apiKey = process.env.API_KEY;
+    const groupId = process.env.GROUP_ID;
+    const appId = process.env.APP_ID;
+
+    // Get configuration from command line arguments
+    const {
+      dryRun: explicitDryRun,
+      verbose,
+      batchSize,
+      outputFile: rawOutputFile,
+      pendingUserDate,
+    } = argv;
+
+    // Ensure output file is in the output directory
+    const outputFile = rawOutputFile
+      ? path.join('output', path.basename(rawOutputFile))
+      : undefined;
+
+    // If no output file is specified, treat it as a dry run
+    const dryRun = explicitDryRun || !outputFile;
+
+    // Validate required environment variables
+    if (!username) {
+      throw new Error(
+        'Username is required. Please set the USERNAME environment variable in your .env file.'
+      );
+    }
+
+    if (!apiKey) {
+      throw new Error(
+        'API key is required. Please set the API_KEY environment variable in your .env file.'
+      );
+    }
+
+    if (!groupId) {
+      throw new Error(
+        'Group ID is required. Please set the GROUP_ID environment variable in your .env file.'
+      );
+    }
+
+    if (!appId) {
+      throw new Error(
+        'App ID is required. Please set the APP_ID environment variable in your .env file.'
+      );
+    }
+
+    // Validate pendingUserDate format
+    if (pendingUserDate && !/^\d{4}-\d{2}-\d{2}$/.test(pendingUserDate)) {
+      throw new Error('pendingUserDate must be in YYYY-MM-DD format');
+    }
+
+    // Log configuration
+    log.debug(verbose, 'Configuration:');
+    log.debug(verbose, `- Group ID: ${groupId}`);
+    log.debug(verbose, `- App ID: ${appId}`);
+    log.debug(verbose, `- Batch size: ${batchSize}`);
+    log.debug(verbose, `- Output file: ${outputFile || 'Not specified'}`);
+    log.debug(
+      verbose,
+      `- Dry run: ${dryRun ? 'Yes' : 'No'}${!outputFile ? ' (no output file specified)' : ''}`
+    );
+    log.debug(verbose, `- Verbose: ${verbose ? 'Yes' : 'No'}`);
+    log.debug(verbose, `- Pending user date: ${pendingUserDate}`);
+
+    // Get API token for authentication
+    const apiToken = await getAPIToken(username, apiKey, verbose);
+    log.success('Authentication successful');
+
+    // Get users from App Services
+    log.info('Fetching users...');
+    const users = await getUsers(apiToken, groupId, appId, verbose);
+    log.success(`Total users: ${users.length}`);
+
+    // Get pending users from App Services
+    log.info('Fetching pending users...');
+    const pendingUsers = await getPendingUsers(apiToken, groupId, appId, pendingUserDate, verbose);
+    log.success(`Total pending users: ${pendingUsers.length}`);
+
+    // Prepare user data
+    const userData = {
+      metadata: {
+        exportDate: new Date().toISOString(),
+        groupId,
+        appId,
+        totalUsers: users.length,
+        totalPendingUsers: pendingUsers.length,
+        pendingUserDate,
+      },
+      users,
+      pendingUsers,
+    };
+
+    // Save users to output file if specified and not in dry run mode
+    if (outputFile && !dryRun) {
+      log.info(`Saving users to ${outputFile}...`);
+
+      // Create output directory if it doesn't exist
+      const outputDir = path.dirname(outputFile);
+      await fs.mkdir(outputDir, { recursive: true });
+
+      // Save users to file
+      await fs.writeFile(outputFile, JSON.stringify(userData, null, 2));
+      log.success(`Users saved to ${outputFile}`);
+    } else {
+      // Either dry run mode or no output file specified
+      log.info('Dry run mode or no output file specified. Logging summary data:');
+      log.info('Metadata:');
+      Object.entries(userData.metadata).forEach(([key, value]) => {
+        log.info(`  ${key}: ${value}`);
+      });
+
+      // Log sample user data if available
+      if (users.length > 0) {
+        log.info('Sample user data (first user):');
+        log.info(JSON.stringify(users[0], null, 2));
+      }
+
+      if (pendingUsers.length > 0) {
+        log.info('Sample pending user data (first pending user):');
+        log.info(JSON.stringify(pendingUsers[0], null, 2));
+      }
+
+      if (!outputFile) {
+        log.warning('No output file specified. Use --outputFile to save data to a file.');
+      } else {
+        log.warning('Dry run mode enabled. Users not saved to file.');
+      }
+    }
+
+    log.success('Migration script completed successfully');
   } catch (error) {
-    console.error('Error in migration script:', error);
+    log.error('Error in migration script:', error);
     process.exit(1);
   }
 };
 
 // Execute the main function
-main().catch((error) => {
-  console.error('Unhandled error:', error);
-  process.exit(1);
-});
+(async () => {
+  await main();
+})();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,56 @@
+/**
+ * Utility functions for the Realm users migration script
+ */
+import chalk from 'chalk';
+
+/**
+ * Logger utility for consistent logging with color formatting
+ *
+ * @example
+ * log.info('Starting process');
+ * log.success('Process completed successfully');
+ * log.warning('Something might be wrong');
+ * log.error('An error occurred', error);
+ * log.debug(verbose, 'Detailed information', data);
+ */
+export const log = {
+  /**
+   * Log informational message in blue
+   * @param {string} message - The message to log
+   * @param {...any} args - Additional arguments to log
+   */
+  info: (message: string, ...args: any[]) => console.log(chalk.blue(message), ...args),
+
+  /**
+   * Log success message in green
+   * @param {string} message - The message to log
+   * @param {...any} args - Additional arguments to log
+   */
+  success: (message: string, ...args: any[]) => console.log(chalk.green(message), ...args),
+
+  /**
+   * Log warning message in yellow
+   * @param {string} message - The message to log
+   * @param {...any} args - Additional arguments to log
+   */
+  warning: (message: string, ...args: any[]) => console.log(chalk.yellow(message), ...args),
+
+  /**
+   * Log error message in red
+   * @param {string} message - The message to log
+   * @param {...any} args - Additional arguments to log
+   */
+  error: (message: string, ...args: any[]) => console.error(chalk.red(message), ...args),
+
+  /**
+   * Log debug message in magenta, only if verbose mode is enabled
+   * @param {boolean} verbose - Whether to show the debug message
+   * @param {string} message - The message to log
+   * @param {...any} args - Additional arguments to log
+   */
+  debug: (verbose: boolean, message: string, ...args: any[]) => {
+    if (verbose) {
+      console.log(chalk.magenta(`[DEBUG] ${message}`), ...args);
+    }
+  },
+};


### PR DESCRIPTION
### TL;DR

Added functionality to extract users from MongoDB Realm/App Services via the Atlas Admin API.

### What changed?

- Created Atlas API integration for user extraction
- Added environment configuration with `.env.example` template
- Implemented command-line interface with options for dry runs, verbosity, and output control
- Added support for both active and pending users
- Created utility functions for consistent logging with color formatting
- Added necessary dependencies (axios, chalk, dotenv, yargs)

### How to test?

1. Copy `.env.example` to `.env` and fill in your MongoDB Atlas credentials:
   - `USERNAME`: Your Atlas public API key
   - `API_KEY`: Your Atlas private API key
   - `PROJECT_ID`: Your Atlas project ID
   - `APP_ID`: The App Services app ID to extract users from

2. Run the script with options:
   ```
   npm start -- --verbose --outputFile=users.json
   ```

3. Additional options:
   - `--dryRun`: Run without making changes
   - `--batchSize=100`: Set number of users per batch
   - `--pendingUserDate=2020-12-01`: Set date for pending users (YYYY-MM-DD format)

### Why make this change?

This implementation provides a way to extract user data from MongoDB Realm/App Services for migration purposes. It allows developers to retrieve both active and pending users with their metadata, which can be exported to a JSON file for further processing or importing into other systems.